### PR TITLE
Add hypothesis test

### DIFF
--- a/requirements_dev.txt
+++ b/requirements_dev.txt
@@ -12,3 +12,4 @@ pytest==3.2.2
 pytest-runner==2.12.1
 pytest-cov==2.5.1
 codecov==2.0.9
+hypothesis==3.79.0

--- a/tests/test_cid.py
+++ b/tests/test_cid.py
@@ -2,12 +2,14 @@ import hashlib
 import multihash
 import pytest
 import base58
+import string
 from morphys import ensure_unicode
 
 import multibase
 import multicodec
 from cid import CIDv0, CIDv1, make_cid, is_cid, from_string
 from multibase.multibase import ENCODINGS
+from hypothesis import given, strategies as st
 
 
 @pytest.fixture(scope='session')
@@ -102,6 +104,10 @@ class CIDTestCase(object):
     def test_is_cidv0_valid(self, test_cidv0):
         assert is_cid(test_cidv0)
         assert is_cid(make_cid(test_cidv0).encode())
+
+    @given(hash=st.text(string.ascii_letters + string.digits))
+    def test_make_cid(self, hash):
+        is_cid(hash)
 
     @pytest.mark.parametrize('test_cidv1', (
         'bafybeigdyrzt5sfp7udm7hu76uh7y26nf3efuylqabf3oclgtqy55fbzdi',


### PR DESCRIPTION
I have added testing with `hypothesis`, which will expose the crash in #17 (it seems to me like `is_cid` should never crash). Hypothesis is a fantastic library to keep around anyway, and this is a good example of how a three-line test exposes bugs that couldn't have been anticipated otherwise.