### PR TITLE
Allow `py-multicodec` 0.2.x

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -14,7 +14,7 @@ with open('HISTORY.rst') as history_file:
 requirements = [
     'base58>=1.0.2,<2.0',
     'py-multibase>=1.0.0,<2.0.0',
-    'py-multicodec<0.2.0',
+    'py-multicodec<0.3.0',
     'morphys>=1.0,<2.0',
     'py-multihash>=0.2.0,<1.0.0',
 ]

--- a/tests/test_cid.py
+++ b/tests/test_cid.py
@@ -185,7 +185,7 @@ class MakeCIDTestCase(object):
     def test_version_0_invalid_codec(self):
         """ make_cid: make_cid does not work if version 0 has incorrect codec """
         with pytest.raises(ValueError) as excinfo:
-            make_cid(0, 'bin', b'multihash')
+            make_cid(0, 'raw', b'multihash')
         assert 'codec for version 0' in str(excinfo.value)
 
     def test_invalid_arguments(self):


### PR DESCRIPTION
Allow using `py-multicodec` 0.2.x.

Changes introduced in 0.2 are multiformats/py-multicodec#6 and https://github.com/multiformats/py-multicodec#7.