### PR TITLE
Multihash check

### DIFF
--- a/cid/cid.py
+++ b/cid/cid.py
@@ -26,6 +26,8 @@ class BaseCID(object):
         self._version = version
         self._codec = codec
         self._multihash = ensure_bytes(multihash)
+        if not mh.is_valid(self._multihash):
+            raise ValueError("Invalid multihash value: {}".format(multihash))
 
     @property
     def version(self):
@@ -74,8 +76,13 @@ class CIDv0(BaseCID):
 
     def __init__(self, multihash):
         """
-        :param bytes multihash: multihash for the CID
+        :param multihash: multihash for the CID
         """
+        if isinstance(multihash, str):
+            try:
+                multihash = base58.b58decode(multihash)
+            except ValueError:
+                raise ValueError("Invalid multihash string: {}. Must be Base58 (non-multibase) encoded".format(multihash))
         super(CIDv0, self).__init__(0, self.CODEC, multihash)
 
     @property
@@ -111,6 +118,11 @@ class CIDv1(BaseCID):
     """ CID version 1 object """
 
     def __init__(self, codec, multihash):
+        if isinstance(multihash, str):
+            try:
+                multihash = multibase.decode(multihash)
+            except ValueError:
+                raise ValueError("Invalid multihash string: {}. Must be Multibase encoded".format(multihash))
         super(CIDv1, self).__init__(1, codec, multihash)
 
     @property

--- a/docs/usage.rst
+++ b/docs/usage.rst
@@ -37,9 +37,8 @@ Working with CIDv1
     >>> make_cid('zdj7WhuEjrB52m1BisYCtmjH1hSKa7yZ3jEZ9JcXaFRD51wVz')
     CIDv1(version=1, codec=dag-pb, multihash=b"\x12 \xb9M'..")
 
-    >>> # or you can provide a multihash directly
-    >>> cid = CIDv1('dag-pb', '<multihash>')
-    CIDv1(version=1, codec=dag-pb, multihash=b'<multihash>')
+    >>> # or you can provide a multibase-encoded multihash directly
+    >>> cid = CIDv1('dag-pb', '<multibase-encoded multihash>')
 
     >>> # you can encode the CID to get its string form
     >>> cid.encode()

--- a/tests/test_cid.py
+++ b/tests/test_cid.py
@@ -61,6 +61,12 @@ class CIDv1TestCase(object):
     def test_init_invalid_multihash(self, raw_multihash):
         with pytest.raises(ValueError):
             CIDv1(self.TEST_CODEC, raw_multihash)
+            CIDv1(self.TEST_CODEC, multibase.encode("base58", raw_multihash).decode())
+
+    @given(string_multihash=st.text().filter(lambda x: not multibase.is_encoded(x)))
+    def test_init_invalid_base_multihash(self, string_multihash):
+        with pytest.raises(ValueError):
+            CIDv1(self.TEST_CODEC, string_multihash)
 
     def test_buffer(self, cid):
         """ .buffer: buffer is computed properly """

--- a/tests/test_cid.py
+++ b/tests/test_cid.py
@@ -57,6 +57,11 @@ class CIDv1TestCase(object):
         assert cid.codec == self.TEST_CODEC
         assert cid.multihash == test_hash
 
+    @given(raw_multihash=st.binary().filter(lambda x: not multihash.is_valid(x)))
+    def test_init_invalid_multihash(self, raw_multihash):
+        with pytest.raises(ValueError):
+            CIDv1(self.TEST_CODEC, raw_multihash)
+
     def test_buffer(self, cid):
         """ .buffer: buffer is computed properly """
         buffer = cid.buffer
@@ -83,8 +88,8 @@ class CIDTestCase(object):
 
     def test_cidv0_neq(self):
         """ check for inequality for CIDv0 for different hashes """
-        assert CIDv0(b'QmdfTbBqBPQ7VNxZEYEj14VmRuZBkqFbiwReogJgS1zR1n') != \
-            CIDv0(b'QmdfTbBqBPQ7VNxZEYEj14VmRuZBkqFbiwReogJgS1zR1o')
+        assert CIDv0('QmdfTbBqBPQ7VNxZEYEj14VmRuZBkqFbiwReogJgS1zR1n') != \
+            CIDv0('QmdfTbBqBPQ7VNxZEYEj14VmRuZBkqFbiwReogJgS1zR1o')
 
     def test_cidv0_eq_cidv1(self, test_hash):
         """ check for equality between converted v0 to v1 """
@@ -94,7 +99,7 @@ class CIDTestCase(object):
         """ check for equality between converted v1 to v0 """
         assert CIDv1(CIDv0.CODEC, test_hash).to_v0() == CIDv0(test_hash)
 
-    def test_cidv1_to_cidv0_no_dag_pb(self):
+    def test_cidv1_to_cidv0_no_dag_pb(self, test_hash):
         """ converting non dag-pb CIDv1 should raise an exception """
         with pytest.raises(ValueError) as excinfo:
             CIDv1('base2', test_hash).to_v0()


### PR DESCRIPTION
### The problem
`Multihash` (bytes and base-encoded) is not being checked when CID is directly instantiated.

### The solution

- Added `Multihash` bytes checker in __init__
- Added possibility to pass string Multihases. For it, base decoders were added in __init__. `CIDv0` must be Base-58 encoded (no-multibase), and `CIDv1` must be multibase-encoded.
