### PR TITLE
remove non-maintained note from README

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -1,15 +1,3 @@
-⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️
-
-2022-09-15:
-
-This repo is not maintained.
-
-If someone would like to fork it and support it, IPLD stewards are happy to point to a supported fork.
-Please open an issue in ipld/ipld requesting this of ask in #ipld in IPFS Discod, Matrix, or FIL Slack.
-
-⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️
-
-
 CID (Content IDentifier)
 ------------------------
 


### PR DESCRIPTION
`py-cid` is back! Removing the note saying that it is not maintained.