### PR TITLE
get readthedocs CI run working

### DIFF
--- a/docs/index.rst
+++ b/docs/index.rst
@@ -15,7 +15,7 @@ Table of contents
    usage
    api_reference
    modules
-   .. contributing
+   contributing
    authors
    history
 


### PR DESCRIPTION
Still not working, not sure why, but fixing docs build warning.