### PR TITLE
Migrate from pymultihash to py-multihash >= 2.0.0

### DIFF
--- a/newsfragments/47.feature.rst
+++ b/newsfragments/47.feature.rst
@@ -1,0 +1,1 @@
+Migrate from pymultihash to py-multihash >= 2.0.0 for better maintenance and modern API support.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -35,7 +35,7 @@ dependencies = [
     "py-multibase>=1.0.0,<2.0.0",
     "py-multicodec<0.3.0",
     "morphys>=1.0,<2.0",
-    "pymultihash>=0.8.0,<1.0.0",
+    "py-multihash>=2.0.0",
 ]
 
 [project.urls]
@@ -154,7 +154,7 @@ combine-as-imports = true
 extra-standard-library = []
 force-sort-within-sections = true
 known-first-party = ["cid", "tests"]
-known-third-party = ["base58", "multibase", "multicodec", "morphys", "pymultihash"]
+known-third-party = ["base58", "multibase", "multicodec", "morphys", "multihash"]
 force-to-top = ["pytest"]
 
 [tool.ruff.format]

--- a/tests/test_cid.py
+++ b/tests/test_cid.py
@@ -1,3 +1,4 @@
+import hashlib
 import string
 
 import pytest
@@ -20,7 +21,8 @@ ALLOWED_ENCODINGS = [encoding for encoding in ENCODINGS if encoding.code != b"\x
 @pytest.fixture(scope="session")
 def test_hash():
     data = b"hello world"
-    return multihash.digest(data, "sha2-256").encode()
+    digest = hashlib.sha256(data).digest()
+    return multihash.encode(digest, "sha2-256")
 
 
 class TestCIDv0:


### PR DESCRIPTION
This PR migrates the codebase from `pymultihash` to `py-multihash >= 2.0.0` for better maintenance and modern API support.

## Changes
- Updated dependency in `pyproject.toml` from `pymultihash>=0.8.0,<1.0.0` to `py-multihash>=2.0.0`
- Updated test code to use new API (replaced `multihash.digest()` with `hashlib` + `multihash.encode()`)
- Updated ruff configuration to reflect new package name
- Added newsfragment for issue #47

## API Migration
- `multihash.digest(data, hash_type)` → Use `hashlib` to create digest, then `multihash.encode(digest, hash_type)`
- `multihash.decode()` remains compatible (still raises ValueError on invalid input)

## Testing
All existing tests pass (76 tests, 97% coverage).

Closes #47