### PR TITLE
Fix: validate multihash in CIDv0 constructor

### DIFF
--- a/cid/cid.py
+++ b/cid/cid.py
@@ -195,6 +195,19 @@ class CIDv0(BaseCID):
         """
         :param bytes multihash: multihash for the CID
         """
+        multihash_bytes = ensure_bytes(multihash)
+        # Validate multihash is sha2-256 with 32-byte digest
+        try:
+            mh_info = mh.decode(multihash_bytes)
+        except Exception as e:
+            raise ValueError(f"invalid multihash for CIDv0: {e}") from e
+
+        if mh_info.code != 0x12 or mh_info.length != 32:
+            raise ValueError(
+                f"invalid hash for CIDv0: must be sha2-256 with 32-byte digest, "
+                f"got {mh_info.name} with {mh_info.length}-byte digest"
+            )
+
         super().__init__(0, self.CODEC, multihash)
 
     @property

--- a/newsfragments/63.bugfix.rst
+++ b/newsfragments/63.bugfix.rst
@@ -1,0 +1,1 @@
+Validate multihash correctness in CIDv0 constructor.

--- a/tests/test_cid.py
+++ b/tests/test_cid.py
@@ -48,6 +48,18 @@ class TestCIDv0:
     def test_str(self, cid):
         assert str(cid) == ensure_unicode(cid.encode())
 
+    def test_cidv0_rejects_non_sha256(self):
+        digest = hashlib.sha3_512(b"hello").digest()
+        mh_bytes = multihash.encode(digest, "sha3-512")
+        with pytest.raises(ValueError, match="must be sha2-256"):
+            CIDv0(mh_bytes)
+
+    def test_cidv0_rejects_truncated_digest(self):
+        digest = hashlib.sha256(b"hello").digest()[:16]
+        mh_bytes = multihash.encode(digest, "sha2-256", 16)
+        with pytest.raises(ValueError, match="32-byte digest"):
+            CIDv0(mh_bytes)
+
 
 class TestCIDv1:
     TEST_CODEC = "dag-pb"
@@ -88,8 +100,8 @@ class TestCID:
 
     def test_cidv0_neq(self):
         """Check for inequality for CIDv0 for different hashes"""
-        assert CIDv0(b"QmdfTbBqBPQ7VNxZEYEj14VmRuZBkqFbiwReogJgS1zR1n") != CIDv0(
-            b"QmdfTbBqBPQ7VNxZEYEj14VmRuZBkqFbiwReogJgS1zR1o",
+        assert CIDv0(base58.b58decode(b"QmdfTbBqBPQ7VNxZEYEj14VmRuZBkqFbiwReogJgS1zR1n")) != CIDv0(
+            base58.b58decode(b"QmdfTbBqBPQ7VNxZEYEj14VmRuZBkqFbiwReogJgS1zR1o"),
         )
 
     def test_cidv0_eq_cidv1(self, test_hash):

--- a/tests/test_new_features.py
+++ b/tests/test_new_features.py
@@ -202,7 +202,9 @@ class TestCIDSet:
         cid_set = CIDSet()
         cid_set.add(cidv0)
         assert cid_set.has(cidv0)
-        assert not cid_set.has(CIDv0(b"different"))
+        different_digest = hashlib.sha256(b"different").digest()
+        different_mh = multihash.encode(different_digest, "sha2-256")
+        assert not cid_set.has(CIDv0(different_mh))
 
     def test_cid_set_remove(self, cidv0):
         """CIDSet.remove: removes CID from set"""
@@ -265,7 +267,9 @@ class TestCIDSet:
         cid_set = CIDSet()
         cid_set.add(cidv0)
         assert cidv0 in cid_set
-        assert CIDv0(b"different") not in cid_set
+        different_digest = hashlib.sha256(b"different").digest()
+        different_mh = multihash.encode(different_digest, "sha2-256")
+        assert CIDv0(different_mh) not in cid_set
 
     def test_cid_set_iter(self, cidv0, cidv1):
         """CIDSet.__iter__: makes set iterable"""


### PR DESCRIPTION
Closes #63

### Description
This PR fixes issue #63 by adding validation to the `CIDv0` constructor to ensure the provided multihash uses the `sha2-256` algorithm and has a 32-byte digest, as required by the CID specification.

### Changes
- Updated `CIDv0.__init__` to decode and validate the multihash code (must be `0x12` for `sha2-256`) and length (must be `32`). Raises a `ValueError` if the multihash is invalid.
- Added tests `test_cidv0_rejects_non_sha256` and `test_cidv0_rejects_truncated_digest` in `tests/test_cid.py`.
- Fixed existing tests in `test_cid.py` and `test_new_features.py` that were improperly creating `CIDv0` objects using non-compliant hashes or raw byte strings (which now fail due to the new strict validation).