### PR TITLE
Fix: Support all hash types in Prefix.sum()

### DIFF
--- a/cid/builder.py
+++ b/cid/builder.py
@@ -1,7 +1,6 @@
 """Builder pattern for CID construction."""
 
 from abc import ABC, abstractmethod
-import hashlib
 from typing import TYPE_CHECKING
 
 import multihash
@@ -59,8 +58,7 @@ class V0Builder(Builder):
         """
         from .cid import CIDv0
 
-        digest = hashlib.sha256(data).digest()
-        mhash = multihash.encode(digest, "sha2-256")
+        mhash = multihash.sum(data, "sha2-256").encode()
         return CIDv0(mhash)
 
     def get_codec(self) -> str:
@@ -113,16 +111,8 @@ class V1Builder(Builder):
         """
         from .cid import CIDv1
 
-        if self.mh_type == "sha2-256":
-            digest = hashlib.sha256(data).digest()
-        elif self.mh_type == "sha2-512":
-            digest = hashlib.sha512(data).digest()
-        else:
-            msg = f"Hash type {self.mh_type} not fully implemented"
-            raise NotImplementedError(msg)
-
         mh_length = None if self.mh_length == -1 else self.mh_length
-        mhash = multihash.encode(digest, self.mh_type, mh_length)
+        mhash = multihash.sum(data, self.mh_type, length=mh_length).encode()
         return CIDv1(self.codec, mhash)
 
     def get_codec(self) -> str:

--- a/cid/prefix.py
+++ b/cid/prefix.py
@@ -1,6 +1,5 @@
 """CID Prefix operations for creating CIDs from data."""
 
-import hashlib
 from typing import TYPE_CHECKING
 
 import multicodec
@@ -111,22 +110,10 @@ class Prefix:
         :rtype: :py:class:`cid.CIDv0` or :py:class:`cid.CIDv1`
         :raises NotImplementedError: if hash type is not supported
         """
-        # Hash data using mh_type
-        if self.mh_type == "sha2-256":
-            digest = hashlib.sha256(data).digest()
-        elif self.mh_type == "sha2-512":
-            digest = hashlib.sha512(data).digest()
-        else:
-            # Use multihash library for other types
-            # This is a simplified implementation - in practice,
-            # you'd want to support more hash types
-            msg = f"Hash type {self.mh_type} not fully implemented"
-            raise NotImplementedError(msg)
-
         # Encode as multihash
         # Pass None if mh_length is -1 (default), otherwise use specified length
         mh_length = None if self.mh_length == -1 else self.mh_length
-        mhash = multihash.encode(digest, self.mh_type, mh_length)
+        mhash = multihash.sum(data, self.mh_type, length=mh_length).encode()
 
         # Create CID
         if self.version == 0:

--- a/newsfragments/64.bugfix.rst
+++ b/newsfragments/64.bugfix.rst
@@ -1,0 +1,1 @@
+Support all standard hash types from multihash library in Prefix.sum().

--- a/tests/test_prefix.py
+++ b/tests/test_prefix.py
@@ -114,6 +114,19 @@ class TestPrefix:
         assert prefix.codec == "raw"
         assert prefix.mh_type == "sha2-512"
 
+    @pytest.mark.parametrize("mh_type", [
+        "sha2-256", "sha2-512", "sha3-256", "sha3-512",
+        "blake2b-256", "identity",
+    ])
+    def test_prefix_sum_various_hash_types(self, mh_type):
+        """Prefix.sum: correctly creates CID from various hash types"""
+        prefix = Prefix.v1(codec="raw", mh_type=mh_type)
+        cid = prefix.sum(b"hello world")
+        assert isinstance(cid, CIDv1)
+        assert cid.codec == "raw"
+        expected_type = "id" if mh_type == "identity" else mh_type
+        assert cid.prefix().mh_type == expected_type
+
 
 class TestCIDPrefix:
     """Tests for CID.prefix() method"""

--- a/tests/test_prefix.py
+++ b/tests/test_prefix.py
@@ -114,10 +114,17 @@ class TestPrefix:
         assert prefix.codec == "raw"
         assert prefix.mh_type == "sha2-512"
 
-    @pytest.mark.parametrize("mh_type", [
-        "sha2-256", "sha2-512", "sha3-256", "sha3-512",
-        "blake2b-256", "identity",
-    ])
+    @pytest.mark.parametrize(
+        "mh_type",
+        [
+            "sha2-256",
+            "sha2-512",
+            "sha3-256",
+            "sha3-512",
+            "blake2b-256",
+            "identity",
+        ],
+    )
     def test_prefix_sum_various_hash_types(self, mh_type):
         """Prefix.sum: correctly creates CID from various hash types"""
         prefix = Prefix.v1(codec="raw", mh_type=mh_type)


### PR DESCRIPTION
Closes #64

### Description
This PR addresses the limitation where `Prefix.sum()` and `V1Builder.sum()` only supported `sha2-256` and `sha2-512` by hardcoding `hashlib.sha256/512`. The hashing logic now correctly delegates to `multihash.sum()` which supports all registered hash functions in `python-multihash`.

### Changes
- Updated `Prefix.sum()` in `cid/prefix.py` to use `multihash.sum()` instead of manually invoking `hashlib` and checking `mh_type`.
- Updated `V0Builder.sum()` and `V1Builder.sum()` in `cid/builder.py` similarly to delegate to `multihash.sum()`.
- Removed unnecessary `hashlib` imports from both modules.
- Added tests in `tests/test_prefix.py` to ensure various multihash types like `sha3-256`, `blake2b-256`, and `identity` are supported.