### PR TITLE
Fix: Support complete multihash type mappings in Prefix

### DIFF
--- a/cid/prefix.py
+++ b/cid/prefix.py
@@ -216,10 +216,10 @@ class Prefix:
     def _mh_type_to_code(mh_type: str) -> int:
         """Convert multihash type name to code."""
         try:
-            return multihash.Func[mh_type.replace("-", "_")].value
+            return multihash.Func[mh_type.replace("-", "_")].value  # type: ignore
         except KeyError:
             try:
-                return multihash.coerce_code(mh_type)
+                return int(multihash.coerce_code(mh_type))  # type: ignore
             except (ValueError, TypeError):
                 msg = f"Unknown multihash type: {mh_type}"
                 raise ValueError(msg)

--- a/cid/prefix.py
+++ b/cid/prefix.py
@@ -215,40 +215,23 @@ class Prefix:
     @staticmethod
     def _mh_type_to_code(mh_type: str) -> int:
         """Convert multihash type name to code."""
-        # Common multihash type codes
-        # These match the multiformats specification
-        mh_codes = {
-            "sha1": 0x11,
-            "sha2-256": 0x12,
-            "sha2-512": 0x13,
-            "sha3-224": 0x17,
-            "sha3-256": 0x16,
-            "sha3-512": 0x14,
-            "blake2b-256": 0xB220,
-            "blake2b-512": 0xB240,
-        }
-        if mh_type not in mh_codes:
-            msg = f"Unknown multihash type: {mh_type}"
-            raise ValueError(msg)
-        return mh_codes[mh_type]
+        try:
+            return multihash.Func[mh_type.replace("-", "_")].value
+        except KeyError:
+            try:
+                return multihash.coerce_code(mh_type)
+            except (ValueError, TypeError):
+                msg = f"Unknown multihash type: {mh_type}"
+                raise ValueError(msg)
 
     @staticmethod
     def _mh_code_to_type(mh_code: int) -> str:
         """Convert multihash code to type name."""
-        mh_types = {
-            0x11: "sha1",
-            0x12: "sha2-256",
-            0x13: "sha2-512",
-            0x17: "sha3-224",
-            0x16: "sha3-256",
-            0x14: "sha3-512",
-            0xB220: "blake2b-256",
-            0xB240: "blake2b-512",
-        }
-        if mh_code not in mh_types:
+        try:
+            return multihash.Func(mh_code).name.replace("_", "-")
+        except ValueError:
             msg = f"Unknown multihash code: {mh_code}"
             raise ValueError(msg)
-        return mh_types[mh_code]
 
     def __eq__(self, other: object) -> bool:
         """Check equality with another Prefix."""

--- a/newsfragments/65.bugfix.rst
+++ b/newsfragments/65.bugfix.rst
@@ -1,0 +1,1 @@
+Delegate multihash type mappings in Prefix to the multihash library.


### PR DESCRIPTION
Closes #65

### Description
This PR addresses the issue where `Prefix._mh_types_to_code()` and `Prefix._mh_code_to_type()` were using a hardcoded, incomplete mapping of only 8 multihash types, which led to `ValueError` on valid multihashes like `identity`, `shake-256`, and `blake3`.

The mapping logic now properly delegates to the `multihash` library which acts as the source of truth for all supported multiformat hash codes.

### Changes
- Replaced the hardcoded mappings in `cid/prefix.py` for both `_mh_types_to_code` and `_mh_code_to_type`.
- `_mh_type_to_code` now uses `multihash.Func` and `multihash.coerce_code()` to look up the type name safely.
- `_mh_code_to_type` now converts the code back to the canonical name via `multihash.Func`.

This enables py-cid to parse and serialize any valid prefix supported by python-multihash.