### PR TITLE
Fix: tox docs testenv extras

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -60,7 +60,6 @@ commands=
 
 [testenv:docs]
 extras=
-    .
     dev
 commands =
     make check-docs-ci


### PR DESCRIPTION
Closes #79

### Description
This PR fixes an issue where the `tox` job for `docs` fails instantly during the CI/CD pipeline. 

The `tox.ini` file erroneously referenced `.` in the `extras` section for `[testenv:docs]`. Since `.` is not a named optional-dependency group in `pyproject.toml`, tox instantly failed with `docs: failed with extras not found for package py-cid: - (available: dev)`. 

### Changes
- Removed the invalid `.` entry from the `extras` list under `[testenv:docs]` in `tox.ini`. The `dev` extra correctly remains.

### Verification
- Ran `tox -e docs` locally and verified that it successfully skips the config failure, installs the `dev` dependencies, and successfully builds the HTML documentation using `make check-docs-ci`.


