### PR TITLE
Feat: Add fuzz testing

### DIFF
--- a/newsfragments/72.feature.rst
+++ b/newsfragments/72.feature.rst
@@ -1,0 +1,1 @@
+Add property-based fuzz testing using `hypothesis` to ensure CID parsing and encoding are robust against arbitrary input and do not crash.

--- a/tests/test_fuzz.py
+++ b/tests/test_fuzz.py
@@ -1,0 +1,24 @@
+import pytest
+from hypothesis import given, strategies as st, settings
+from cid import make_cid, CIDv1, CIDv0
+
+@given(st.binary(max_size=200))
+@settings(max_examples=1000)
+def test_from_bytes_never_crashes(data):
+    """from_bytes should raise ValueError, KeyError, or TypeError, not crash."""
+    try:
+        make_cid(data)
+    except (ValueError, KeyError, TypeError):
+        pass  # Any exception is fine, just no crashes
+
+@given(st.binary(min_size=34, max_size=100))
+@settings(max_examples=500)
+def test_cid_roundtrip_never_crashes(data):
+    """CID encode/decode should never crash."""
+    try:
+        cid = make_cid(data)
+        _ = cid.encode()
+        _ = str(cid)
+        _ = cid.prefix()
+    except (ValueError, KeyError, TypeError):
+        pass

--- a/tests/test_fuzz.py
+++ b/tests/test_fuzz.py
@@ -1,6 +1,11 @@
-import pytest
-from hypothesis import given, strategies as st, settings
-from cid import make_cid, CIDv1, CIDv0
+from hypothesis import (
+    given,
+    settings,
+    strategies as st,
+)
+
+from cid import make_cid
+
 
 @given(st.binary(max_size=200))
 @settings(max_examples=1000)

--- a/tests/test_fuzz.py
+++ b/tests/test_fuzz.py
@@ -16,6 +16,7 @@ def test_from_bytes_never_crashes(data):
     except (ValueError, KeyError, TypeError):
         pass  # Any exception is fine, just no crashes
 
+
 @given(st.binary(min_size=34, max_size=100))
 @settings(max_examples=500)
 def test_cid_roundtrip_never_crashes(data):


### PR DESCRIPTION
Closes #72

### Description
This PR adds property-based fuzz testing using the `hypothesis` library to ensure that `py-cid` can handle arbitrary or malformed input without crashing unexpectedly.

Previously, `py-cid` lacked fuzz tests, while Go's `go-cid` implementation includes extensive fuzz testing.

### Changes
- Created `tests/test_fuzz.py`.
- Added `test_from_bytes_never_crashes` which passes arbitrary byte strings up to 200 bytes to `make_cid()` and ensures that only expected validation errors (`ValueError`, `KeyError`, `TypeError`) are raised, preventing unhandled crashes.
- Added `test_cid_roundtrip_never_crashes` which verifies that successfully parsed CIDs can be safely encoded, converted to string, and prefixed without crashing.
