### PR TITLE
Feat: Add benchmark tests

### DIFF
--- a/newsfragments/71.feature.rst
+++ b/newsfragments/71.feature.rst
@@ -1,0 +1,1 @@
+Add `pytest-benchmark` based performance benchmarking tests to evaluate `Cid.prefix`, `Cid.encode`, and `Prefix.sum` execution speeds.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -64,6 +64,7 @@ dev = [
     "pre-commit>=3.0.0",
     "towncrier>=24,<25",
     "pyrefly>=0.17.1,<0.18.0",
+    "pytest-benchmark>=4.0.0",
 ]
 
 [tool.setuptools]

--- a/tests/test_benchmarks.py
+++ b/tests/test_benchmarks.py
@@ -1,0 +1,42 @@
+import hashlib
+
+import pytest
+import multihash
+
+from cid import CIDv1, Prefix, make_cid
+
+
+@pytest.fixture
+def bench_cid():
+    data = b"benchmark data" * 100
+    digest = hashlib.sha256(data).digest()
+    mh_bytes = multihash.encode(digest, "sha2-256")
+    return CIDv1("raw", mh_bytes)
+
+
+@pytest.mark.benchmark
+def test_bench_cid_buffer(benchmark, bench_cid):
+    benchmark(lambda: bench_cid.buffer)
+
+
+@pytest.mark.benchmark
+def test_bench_cid_encode(benchmark, bench_cid):
+    benchmark(bench_cid.encode)
+
+
+@pytest.mark.benchmark
+def test_bench_cid_prefix(benchmark, bench_cid):
+    benchmark(bench_cid.prefix)
+
+
+@pytest.mark.benchmark
+def test_bench_prefix_sum(benchmark):
+    prefix = Prefix.v1(codec="raw", mh_type="sha2-256")
+    data = b"benchmark data" * 100
+    benchmark(prefix.sum, data)
+
+
+@pytest.mark.benchmark
+def test_bench_make_cid(benchmark, bench_cid):
+    cid_str = str(bench_cid)
+    benchmark(make_cid, cid_str)


### PR DESCRIPTION
Closes #71

### Description
This PR adds benchmark tests using `pytest-benchmark` to evaluate the performance of core `py-cid` operations. Previously, there were no benchmarks to track performance regressions or compare Python speeds with `go-cid`.

### Changes
- Added `pytest-benchmark>=4.0.0` as a development dependency in `pyproject.toml`.
- Added `tests/test_benchmarks.py` with benchmarks for:
  - `cid.buffer`
  - `cid.encode`
  - `cid.prefix`
  - `prefix.sum`
  - `make_cid`
